### PR TITLE
Update depencies and improve build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,18 @@ FROM python:3.7-alpine as build
 RUN apk add --no-cache --progress \
         build-base \
         cargo \
-        curl \
+        git \
         libffi-dev \
         openssl-dev
 
 WORKDIR /wheels
 RUN pip install -U pip
-RUN curl -L https://raw.githubusercontent.com/Syncplay/syncplay/v1.6.7/requirements.txt | \
-    pip wheel -r /dev/stdin
+# Unless this environment variable is set, Syncplay's setup.py tries to grab GUI dependencies
+RUN SNAPCRAFT_PART_BUILD=1 pip wheel git+https://github.com/syncplay/syncplay.git@v1.6.7#egg=syncplay
 
 FROM python:3.7-alpine
 
 RUN  apk add --no-cache --update --progress \
-        git \
         openssl \
         libffi
 
@@ -23,18 +22,14 @@ COPY --from=build /wheels /wheels
 WORKDIR /wheels
 RUN pip install *.whl
 
-RUN mkdir /app/syncplay -p
-RUN git clone https://github.com/Syncplay/syncplay -b v1.6.7 /app/syncplay
-
 EXPOSE 8999
 COPY ./entrypoint.sh /entrypoint.sh
 
 # Run as non-root user                                                                                                  
+WORKDIR /app/syncplay
 RUN addgroup -g 800 -S syncplay && \
     adduser -u 800 -S syncplay -G syncplay && \
     chown -R syncplay:syncplay /app/syncplay
 
 USER syncplay
-
-WORKDIR /app/syncplay
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM python:3.7-alpine
 
 RUN  apk add --no-cache --update --progress \
         build-base \
-        bash \
         git \
         cargo \
         openssl-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,27 @@
+FROM python:3.7-alpine as build
+
+RUN apk add --no-cache --progress \
+        build-base \
+        cargo \
+        curl \
+        libffi-dev \
+        openssl-dev
+
+WORKDIR /wheels
+RUN pip install -U pip
+RUN curl -L https://raw.githubusercontent.com/Syncplay/syncplay/v1.6.7/requirements.txt | \
+    pip wheel -r /dev/stdin
+
 FROM python:3.7-alpine
 
 RUN  apk add --no-cache --update --progress \
-        build-base \
         git \
-        cargo \
-        openssl-dev \
-        libffi-dev
+        openssl \
+        libffi
 
-#ENV PYTHON_PIP_VERSION 8.1.0
-RUN pip install -q --no-cache-dir --upgrade pip && \
-    pip install \
-        twisted \
-        certifi \
-        pyopenssl \
-        service_identity \
-        idna \
-        cryptography
+COPY --from=build /wheels /wheels
+WORKDIR /wheels
+RUN pip install *.whl
 
 RUN mkdir /app/syncplay -p
 RUN git clone https://github.com/Syncplay/syncplay -b v1.6.7 /app/syncplay

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,14 +22,14 @@ COPY --from=build /wheels /wheels
 WORKDIR /wheels
 RUN pip install *.whl
 
-EXPOSE 8999
-COPY ./entrypoint.sh /entrypoint.sh
-
 # Run as non-root user                                                                                                  
 WORKDIR /app/syncplay
 RUN addgroup -g 800 -S syncplay && \
     adduser -u 800 -S syncplay -G syncplay && \
     chown -R syncplay:syncplay /app/syncplay
 
+COPY ./entrypoint.sh /entrypoint.sh
+
+EXPOSE 8999
 USER syncplay
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 FROM python:3.7-alpine
 
 RUN  apk add --no-cache --update --progress \
-        musl \
         build-base \
         bash \
         git \
         libressl-dev \
-        musl-dev \
         libffi-dev
 
 #ENV PYTHON_PIP_VERSION 8.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN  apk add --no-cache --update --progress \
         build-base \
         bash \
         git \
-        libressl-dev \
+        cargo \
+        openssl-dev \
         libffi-dev
 
 #ENV PYTHON_PIP_VERSION 8.1.0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,4 +28,4 @@ if [ -n "$TLS" ]; then
 fi
 
 
-exec $(eval "./syncplayServer.py $args $@")
+PYTHONUNBUFFERED=1 exec syncplay-server $args $@


### PR DESCRIPTION
I initially started this PR to just update the dependencies, so that cryptography—now requiring Rust—would build again. In doing so, however, I noticed that the new build dependencies for cryptography made the image balloon in size.
To remedy that, I moved the dependency building to a separate stage. After doing so, I realized the build could be further simplified by not just building the dependencies in that stage, but also Syncplay itself, as it provides a console_scripts entry point for the server.

With all that, on top of the fixes, the image is now nearly 4x smaller than before (389 MB -> 100 MB).