### PR TITLE
Stop installing gui requirements for syncplay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,14 @@ RUN apk add --no-cache --progress \
         libffi-dev \
         openssl-dev
 
+WORKDIR /source
+RUN git clone --depth=1 --branch=v1.6.8 https://github.com/syncplay/syncplay.git ./ && \
+    echo "" > requirements_gui.txt
+
 WORKDIR /wheels
 RUN pip install -U pip
 # Unless this environment variable is set, Syncplay's setup.py tries to grab GUI dependencies
-RUN SNAPCRAFT_PART_BUILD=1 pip wheel git+https://github.com/syncplay/syncplay.git@v1.6.8#egg=syncplay
+RUN SNAPCRAFT_PART_BUILD=1 pip wheel file:///source#egg=syncplay
 
 FROM python:3.7-alpine
 


### PR DESCRIPTION
Problem when building image: Could not find a version that satisfies the requirement pyside2>=5.11.0 (from syncplay).

```
podman build .
```

```
[1/2] STEP 1/5: FROM python:3.7-alpine AS build
[1/2] STEP 2/5: RUN apk add --no-cache --progress build-base cargo git libffi-dev openssl-dev
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
(1/38) Installing libgcc (10.3.1_git20210424-r2)
(2/38) Installing libstdc++ (10.3.1_git20210424-r2)
(3/38) Installing binutils (2.35.2-r2)
(4/38) Installing libmagic (5.40-r1)
(5/38) Installing file (5.40-r1)
(6/38) Installing libgomp (10.3.1_git20210424-r2)
(7/38) Installing libatomic (10.3.1_git20210424-r2)
(8/38) Installing libgphobos (10.3.1_git20210424-r2)
(9/38) Installing gmp (6.2.1-r0)
(10/38) Installing isl22 (0.22-r0)
(11/38) Installing mpfr4 (4.1.0-r0)
(12/38) Installing mpc1 (1.2.1-r0)
(13/38) Installing gcc (10.3.1_git20210424-r2)
(14/38) Installing musl-dev (1.2.2-r3)
(15/38) Installing libc-dev (0.7.2-r3)
(16/38) Installing g++ (10.3.1_git20210424-r2)
(17/38) Installing make (4.3-r0)
(18/38) Installing fortify-headers (1.1-r1)
(19/38) Installing patch (2.7.6-r7)
(20/38) Installing build-base (0.5-r2)
(21/38) Installing rust-stdlib (1.52.1-r1)
(22/38) Installing libxml2 (2.9.12-r1)
(23/38) Installing llvm11-libs (11.1.0-r2)
(24/38) Installing brotli-libs (1.0.9-r5)
(25/38) Installing nghttp2-libs (1.43.0-r0)
(26/38) Installing libcurl (7.79.1-r0)
(27/38) Installing http-parser (2.9.4-r0)
(28/38) Installing pcre (8.44-r0)
(29/38) Installing libssh2 (1.9.0-r1)
(30/38) Installing libgit2 (1.1.0-r2)
(31/38) Installing rust (1.52.1-r1)
(32/38) Installing cargo (1.52.1-r1)
(33/38) Installing pcre2 (10.36-r0)
(34/38) Installing git (2.32.0-r0)
(35/38) Installing linux-headers (5.10.41-r0)
(36/38) Installing pkgconf (1.7.4-r0)
(37/38) Installing libffi-dev (3.3-r2)
(38/38) Installing openssl-dev (1.1.1l-r0)
Executing busybox-1.33.1-r3.trigger
OK: 959 MiB in 73 packages
--> d84d5e181d5
[1/2] STEP 3/5: WORKDIR /wheels
--> cdc3aad1650
[1/2] STEP 4/5: RUN pip install -U pip
Requirement already satisfied: pip in /usr/local/lib/python3.7/site-packages (21.2.4)
Collecting pip
  Downloading pip-21.3.1-py3-none-any.whl (1.7 MB)
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 21.2.4
    Uninstalling pip-21.2.4:
      Successfully uninstalled pip-21.2.4
Successfully installed pip-21.3.1
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
--> e4b5fb37147
[1/2] STEP 5/5: RUN SNAPCRAFT_PART_BUILD=1 pip wheel git+https://github.com/syncplay/syncplay.git@v1.6.8#egg=syncplay
Collecting syncplay
  Cloning https://github.com/syncplay/syncplay.git (to revision v1.6.8) to /tmp/pip-wheel-biw2dekl/syncplay_41ca2bbf14f5463c9531edd8dee174ae
  Running command git clone --filter=blob:none -q https://github.com/syncplay/syncplay.git /tmp/pip-wheel-biw2dekl/syncplay_41ca2bbf14f5463c9531edd8dee174ae
  Running command git checkout -q 896d30430c0fa78786990d029df584b899717df9
  Resolved https://github.com/syncplay/syncplay.git to commit 896d30430c0fa78786990d029df584b899717df9
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Collecting certifi>=2018.11.29
  Downloading certifi-2021.10.8-py2.py3-none-any.whl (149 kB)
Collecting twisted[tls]>=16.4.0
  Downloading Twisted-21.7.0-py3-none-any.whl (3.1 MB)
ERROR: Could not find a version that satisfies the requirement pyside2>=5.11.0 (from syncplay) (from versions: none)
ERROR: No matching distribution found for pyside2>=5.11.0
[2/2] STEP 1/11: FROM python:3.7-alpine
Error: error building at STEP "RUN SNAPCRAFT_PART_BUILD=1 pip wheel git+https://github.com/syncplay/syncplay.git@v1.6.8#egg=syncplay": error while running runtime: exit status 1
```

### Implemented solution

Disable gui requirements before building syncplay from source for a server-only container image.