### PR TITLE
Add ARGs to specify uid and gid, fix #6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,13 @@ COPY --from=build /wheels /wheels
 WORKDIR /wheels
 RUN pip install *.whl
 
-# Run as non-root user                                                                                                  
+# Run as non-root user
+ARG USER_UID=800
+ARG USER_GID=800
+
 WORKDIR /app/syncplay
-RUN addgroup -g 800 -S syncplay && \
-    adduser -u 800 -S syncplay -G syncplay && \
+RUN addgroup -g "${USER_GID}" -S syncplay && \
+    adduser -u "${USER_UID}" -S syncplay -G syncplay && \
     chown -R syncplay:syncplay /app/syncplay
 
 COPY ./entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
To use the feature, build the image with build args:

```sh
docker build --build-arg USER_UID=1000 --build-arg USER_GID=1000 .
# or
podman build --build-arg USER_UID=1000 --build-arg USER_GID=1000 .
```

By default UID and GID are both 800 (as in previous versions).

Fixes #6