### PR TITLE
Fix MOTD duplication

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@ if [ -n "$ISOLATE" ]; then
 fi
 
 if [ -n "$MOTD" ]; then
-  echo "$MOTD" >> /app/syncplay/motd
+  echo "$MOTD" > /app/syncplay/motd
   args="$args --motd-file=/app/syncplay/motd"
 fi
 


### PR DESCRIPTION
`>>` Inserts a new line into the motd file on every container restart
This has the effect that with every container restart, an additional line gets added to the motd file
As an example, let's say the MOTD env variable is set to "hello"
on first container startup, the motd file would contain
"hello"

on second startup
"hello
hello"

on third startup
"hello
hello
hello"

and so on

`>` overwrites the content of a file, so that fixes this